### PR TITLE
MB-159: Remove Admin Url Declarations from `config.xml`

### DIFF
--- a/app/code/community/Meanbee/Tinymce5/etc/config.xml
+++ b/app/code/community/Meanbee/Tinymce5/etc/config.xml
@@ -27,18 +27,6 @@
 			</tinymce5>
 		</helpers>
 	</global>
-	
-	<admin>    
-        <routers>
-            <tinymce5>
-                <use>admin</use>
-                <args>
-                        <module>Meanbee_Tinymce5</module>
-                        <frontName>tinymce5</frontName>
-                </args>
-            </tinymce5>
-        </routers>
-    </admin>
 		
     <adminhtml>
         <layout>


### PR DESCRIPTION
No admin urls are used so we don't need to declare an admin route.
